### PR TITLE
Add block parser

### DIFF
--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -17,7 +17,7 @@ pub enum Inline {
     Anchor(Anchor),
     Bold(Bold),
     Italic(Italic),
-    Text(Text)
+    Text(Text),
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct Heading<'a> {
@@ -26,13 +26,13 @@ pub struct Heading<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Paragraph<'a>(pub &'a str);
+pub struct Paragraph(pub Inline);
 
 #[derive(Debug)]
 pub enum LeafBlock<'a> {
     LeafBlock,
     Inline,
-    Paragraph(Paragraph<'a>),
+    Paragraph(Inline),
     Heading(&'a Heading<'a>),
 }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -32,7 +32,7 @@ pub struct Paragraph(pub Vec<Inline>);
 pub enum LeafBlock<'a> {
     LeafBlock,
     Inline,
-    Paragraph(Inline),
+    Paragraph(Paragraph),
     Heading(&'a Heading<'a>),
 }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -26,7 +26,7 @@ pub struct Heading<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Paragraph(pub Inline);
+pub struct Paragraph(pub Vec<Inline>);
 
 #[derive(Debug)]
 pub enum LeafBlock<'a> {

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -4,6 +4,9 @@ pub struct Italic(pub String);
 pub struct Bold(pub String);
 
 #[derive(Debug, PartialEq)]
+pub struct Text(pub String);
+
+#[derive(Debug, PartialEq)]
 pub struct Anchor {
     pub link: String,
     pub title: String,
@@ -14,6 +17,7 @@ pub enum Inline {
     Anchor(Anchor),
     Bold(Bold),
     Italic(Italic),
+    Text(Text)
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct Heading<'a> {

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -15,21 +15,20 @@ pub enum Inline {
     Bold(Bold),
     Italic(Italic),
 }
-#[derive(Debug)]
-pub struct Paragraph {
-    content: String,
-}
 #[derive(Debug, PartialEq, Eq)]
 pub struct Heading<'a> {
     pub content: &'a str,
     pub level: u8,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct Paragraph<'a>(pub &'a str);
+
 #[derive(Debug)]
 pub enum LeafBlock<'a> {
     LeafBlock,
     Inline,
-    Paragraph(Paragraph),
+    Paragraph(Paragraph<'a>),
     Heading(&'a Heading<'a>),
 }
 

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -20,8 +20,8 @@ pub enum Inline {
     Text(Text),
 }
 #[derive(Debug, PartialEq, Eq)]
-pub struct Heading<'a> {
-    pub content: &'a str,
+pub struct Heading {
+    pub content: String,
     pub level: u8,
 }
 
@@ -29,21 +29,21 @@ pub struct Heading<'a> {
 pub struct Paragraph(pub Vec<Inline>);
 
 #[derive(Debug)]
-pub enum LeafBlock<'a> {
+pub enum LeafBlock {
     LeafBlock,
     Inline,
     Paragraph(Paragraph),
-    Heading(&'a Heading<'a>),
+    Heading(Heading),
 }
 
-enum ContainerBlock<'a> {
-    BlockQuotes(&'a LeafBlock<'a>),
+enum ContainerBlock {
+    BlockQuotes(LeafBlock),
     ListItems,
 }
 
 #[derive(Debug)]
-pub enum Ast<'a> {
-    LeafBlock(&'a LeafBlock<'a>),
+pub enum Ast {
+    LeafBlock(LeafBlock),
     ContainerBlock,
     Inline,
 }

--- a/src/ast/ast.rs
+++ b/src/ast/ast.rs
@@ -28,7 +28,7 @@ pub struct Heading {
 #[derive(Debug, PartialEq)]
 pub struct Paragraph(pub Vec<Inline>);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum LeafBlock {
     LeafBlock,
     Inline,
@@ -36,14 +36,8 @@ pub enum LeafBlock {
     Heading(Heading),
 }
 
-enum ContainerBlock {
-    BlockQuotes(LeafBlock),
-    ListItems,
-}
-
-#[derive(Debug)]
-pub enum Ast {
-    LeafBlock(LeafBlock),
-    ContainerBlock,
-    Inline,
+#[derive(Debug, PartialEq)]
+pub enum Document {
+    LeafBlocks(Vec<LeafBlock>),
+    Inline(Inline),
 }

--- a/src/ast/block.rs
+++ b/src/ast/block.rs
@@ -1,1 +1,2 @@
 pub mod heading;
+pub mod paragraph;

--- a/src/ast/block.rs
+++ b/src/ast/block.rs
@@ -1,22 +1,25 @@
-use combine::{Parser, RangeStream, ParseError, attempt, choice};
+use combine::{attempt, choice, ParseError, Parser, RangeStream};
 
-use self::{paragraph::parse_paragraph, heading::{parse_heading_1, parse_heading_2, parse_heading_3}};
+use self::{
+    heading::{parse_heading_1, parse_heading_2, parse_heading_3},
+    paragraph::parse_paragraph,
+};
 
 use super::ast::LeafBlock;
 
 pub mod heading;
 pub mod paragraph;
 
-pub fn parse_block<'a, Input>() -> impl Parser<Input, Output = LeafBlock<'a>>
+pub fn parse_block<'a, Input>() -> impl Parser<Input, Output = LeafBlock>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let parsers = (
-        attempt(parse_paragraph()).map(|p|{LeafBlock::Paragraph(p)}),
-        attempt(parse_heading_1()).map(|h1|{LeafBlock::Heading(&h1)}),
-        attempt(parse_heading_2()).map(|h2|{LeafBlock::Heading(&h2)}),
-        attempt(parse_heading_3()).map(|h3|{LeafBlock::Heading(&h3)}),
+        attempt(parse_paragraph()).map(|p| LeafBlock::Paragraph(p)),
+        attempt(parse_heading_1()).map(|h1| LeafBlock::Heading(h1)),
+        attempt(parse_heading_2()).map(|h2| LeafBlock::Heading(h2)),
+        attempt(parse_heading_3()).map(|h3| LeafBlock::Heading(h3)),
     );
     choice(parsers)
 }

--- a/src/ast/block.rs
+++ b/src/ast/block.rs
@@ -1,2 +1,22 @@
+use combine::{Parser, RangeStream, ParseError, attempt, choice};
+
+use self::{paragraph::parse_paragraph, heading::{parse_heading_1, parse_heading_2, parse_heading_3}};
+
+use super::ast::LeafBlock;
+
 pub mod heading;
 pub mod paragraph;
+
+pub fn parse_block<'a, Input>() -> impl Parser<Input, Output = LeafBlock<'a>>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    let parsers = (
+        attempt(parse_paragraph()).map(|p|{LeafBlock::Paragraph(p)}),
+        attempt(parse_heading_1()).map(|h1|{LeafBlock::Heading(&h1)}),
+        attempt(parse_heading_2()).map(|h2|{LeafBlock::Heading(&h2)}),
+        attempt(parse_heading_3()).map(|h3|{LeafBlock::Heading(&h3)}),
+    );
+    choice(parsers)
+}

--- a/src/ast/block.rs
+++ b/src/ast/block.rs
@@ -16,10 +16,32 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let parsers = (
-        attempt(parse_paragraph()).map(|p| LeafBlock::Paragraph(p)),
         attempt(parse_heading_1()).map(|h1| LeafBlock::Heading(h1)),
         attempt(parse_heading_2()).map(|h2| LeafBlock::Heading(h2)),
         attempt(parse_heading_3()).map(|h3| LeafBlock::Heading(h3)),
+        attempt(parse_paragraph()).map(|p| LeafBlock::Paragraph(p)),
     );
     choice(parsers)
+}
+
+#[cfg(test)]
+mod tests {
+    use combine::Parser;
+
+    use crate::ast::{
+        ast::{Heading, LeafBlock},
+        block::parse_block,
+    };
+
+    #[test]
+    fn it_works() {
+        let input = "## h2";
+        let mut parser = parse_block();
+        let res = parser.parse(input);
+        let italic = Heading {
+            level: 2,
+            content: "h2".to_string(),
+        };
+        assert_eq!(res.unwrap().0, LeafBlock::Heading(italic))
+    }
 }

--- a/src/ast/block/heading.rs
+++ b/src/ast/block/heading.rs
@@ -6,9 +6,12 @@ use combine::{
     ParseError, Parser, RangeStream,
 };
 
-use crate::Heading;
+use crate::{
+    ast::{ast::Inline, inline::text::parse_text},
+    Heading,
+};
 
-pub fn parse_heading_1<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+pub fn parse_heading_1<'a, Input>() -> impl Parser<Input, Output = Heading>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
@@ -16,16 +19,20 @@ where
     let heading_content = (
         string("#"),
         space(),
-        take_while1(|c: char| c.is_alphabetic()),
+        // こうすれば take_while 使わなくて良い。
+        parse_text(),
     )
-        .map(|(_, _, content)| Heading {
-            level: 1,
-            content: content,
+        .map(|(_, _, content)| match content {
+            Inline::Text(text) => Heading {
+                level: 1,
+                content: text.0,
+            },
+            _ => panic!(""),
         });
     heading_content
 }
 
-pub fn parse_heading_2<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+pub fn parse_heading_2<'a, Input>() -> impl Parser<Input, Output = Heading>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
@@ -33,16 +40,20 @@ where
     let heading_content = (
         string("##"),
         space(),
-        take_while1(|c: char| c.is_alphabetic()),
+        // こうすれば take_while 使わなくて良い。
+        parse_text(),
     )
-        .map(|(_, _, content)| Heading {
-            level: 2,
-            content: content,
+        .map(|(_, _, content)| match content {
+            Inline::Text(text) => Heading {
+                level: 2,
+                content: text.0,
+            },
+            _ => panic!(""),
         });
     heading_content
 }
 
-pub fn parse_heading_3<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+pub fn parse_heading_3<'a, Input>() -> impl Parser<Input, Output = Heading>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
@@ -50,19 +61,24 @@ where
     let heading_content = (
         string("###"),
         space(),
-        take_while1(|c: char| c.is_alphabetic()),
+        // こうすれば take_while 使わなくて良い。
+        parse_text(),
     )
-        .map(|(_, _, content)| Heading {
-            level: 3,
-            content: content,
+        .map(|(_, _, content)| match content {
+            Inline::Text(text) => Heading {
+                level: 3,
+                content: text.0,
+            },
+            _ => panic!(""),
         });
     heading_content
 }
-
-
 #[cfg(test)]
 mod tests {
-    use crate::ast::{ast::Heading, block::heading::{parse_heading_2, parse_heading_3}};
+    use crate::ast::{
+        ast::Heading,
+        block::heading::{parse_heading_2, parse_heading_3},
+    };
 
     use super::parse_heading_1;
     use combine::Parser;
@@ -76,7 +92,7 @@ mod tests {
             res.unwrap().0,
             Heading {
                 level: 1,
-                content: "aaa"
+                content: "aaa".to_string()
             }
         );
     }
@@ -90,7 +106,7 @@ mod tests {
             res.unwrap().0,
             Heading {
                 level: 2,
-                content: "aaa"
+                content: "aaa".to_string()
             }
         );
     }
@@ -104,7 +120,7 @@ mod tests {
             res.unwrap().0,
             Heading {
                 level: 3,
-                content: "aaa"
+                content: "aaa".to_string()
             }
         );
     }

--- a/src/ast/block/heading.rs
+++ b/src/ast/block/heading.rs
@@ -8,7 +8,7 @@ use combine::{
 
 use crate::Heading;
 
-pub fn parse_heading<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+pub fn parse_heading_1<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
@@ -25,22 +25,85 @@ where
     heading_content
 }
 
+pub fn parse_heading_2<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    let heading_content = (
+        string("##"),
+        space(),
+        take_while1(|c: char| c.is_alphabetic()),
+    )
+        .map(|(_, _, content)| Heading {
+            level: 2,
+            content: content,
+        });
+    heading_content
+}
+
+pub fn parse_heading_3<'a, Input>() -> impl Parser<Input, Output = Heading<'a>>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    let heading_content = (
+        string("###"),
+        space(),
+        take_while1(|c: char| c.is_alphabetic()),
+    )
+        .map(|(_, _, content)| Heading {
+            level: 3,
+            content: content,
+        });
+    heading_content
+}
+
+
 #[cfg(test)]
 mod tests {
-    use crate::ast::ast::Heading;
+    use crate::ast::{ast::Heading, block::heading::{parse_heading_2, parse_heading_3}};
 
-    use super::parse_heading;
+    use super::parse_heading_1;
     use combine::Parser;
 
     #[test]
-    fn it_works() {
+    fn it_works_1() {
         let input = "# aaa";
-        let mut parser = parse_heading();
+        let mut parser = parse_heading_1();
         let res = parser.parse(input);
         assert_eq!(
             res.unwrap().0,
             Heading {
                 level: 1,
+                content: "aaa"
+            }
+        );
+    }
+
+    #[test]
+    fn it_works_2() {
+        let input = "## aaa";
+        let mut parser = parse_heading_2();
+        let res = parser.parse(input);
+        assert_eq!(
+            res.unwrap().0,
+            Heading {
+                level: 2,
+                content: "aaa"
+            }
+        );
+    }
+
+    #[test]
+    fn it_works_3() {
+        let input = "### aaa";
+        let mut parser = parse_heading_3();
+        let res = parser.parse(input);
+        assert_eq!(
+            res.unwrap().0,
+            Heading {
+                level: 3,
                 content: "aaa"
             }
         );

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -1,42 +1,34 @@
-use combine::{
-    parser::{
-        char::{char, space, string},
-        range::take_while1,
-    },
-    ParseError, Parser, RangeStream,
-};
+use crate::ast::{ast::Paragraph, inline::parse_inline};
+use combine::{parser::char::char, ParseError, Parser, RangeStream};
 
-use crate::{ast::ast::Paragraph, Heading};
-
-pub fn parse_paragraph<'a, Input>() -> impl Parser<Input, Output = Paragraph<'a>>
+pub fn parse_paragraph<'a, Input>() -> impl Parser<Input, Output = Paragraph>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    let heading_content = (
-        char('\n'),
-        take_while1(|c: char| c.is_alphabetic()),
-        char('\n'),
-    )
-        .map(|(_, content, _)| Paragraph(content));
+    let heading_content =
+        (char('\n'), parse_inline(), char('\n')).map(|(_, content, _)| Paragraph(content));
     heading_content
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::ast::Paragraph;
+    use crate::ast::ast::{Inline, Paragraph, Text};
 
     use super::parse_paragraph;
     use combine::Parser;
 
     #[test]
-    fn it_works(){
+    fn it_works() {
         // TODO: Use indoc!
         let input = r#"
 aaa
 "#;
         let mut parser = parse_paragraph();
         let res = parser.parse(input);
-        assert_eq!(res.unwrap().0, Paragraph("aaa"));
+        let text = Text("aaa".to_string());
+        let inline = Inline::Text(text);
+        let paragraph = Paragraph(inline);
+        assert_eq!(res.unwrap().0, paragraph);
     }
 }

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     ast::{Inline, Paragraph},
-    inline::parse_inline,
+    inline::{parse_inline, text::parse_text},
 };
 use combine::{many, parser::char::char, ParseError, Parser, RangeStream};
 
@@ -9,11 +9,7 @@ where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    let inlines = many(parse_inline());
-
-    let heading_content =
-        (char('\n'), inlines, char('\n')).map(|(_, content, _)| Paragraph(content));
-    heading_content
+    many(parse_inline()).map(|x| Paragraph(x))
 }
 
 #[cfg(test)]
@@ -24,30 +20,23 @@ mod tests {
     use combine::Parser;
 
     #[test]
-    fn it_works() {
-        // TODO: Use indoc!
-        let input = r#"
-aaa
-"#;
+    fn it_works_inlines_with_single() {
+        let input = "*italic*";
         let mut parser = parse_paragraph();
-        println!("p");
         let res = parser.parse(input);
-        println!("{:?}", res);
-        let text = Text("aaa".to_string());
-        let inline = Inline::Text(text);
-        let paragraph = Paragraph(vec![inline]);
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inlines = vec![inline_italic];
+        let paragraph = Paragraph(inlines);
         assert_eq!(res.unwrap().0, paragraph);
     }
 
     #[test]
-    fn it_works_with_inlines() {
-        // TODO: Use indoc!
-        let input = r#"
-aaa [hoge](http://localhost:3000) *italic* is not **bold**
-"#;
+    fn it_works_inlines() {
+        let input = "aaa [hoge](http://localhost:3000) *italic* is not **bold**";
         let mut parser = parse_paragraph();
         let res = parser.parse(input);
-        let text = Text("aaa".to_string());
+        let text = Text("aaa ".to_string());
         let inline_text = Inline::Text(text);
         let anchor = Anchor {
             title: "hoge".to_string(),
@@ -56,17 +45,35 @@ aaa [hoge](http://localhost:3000) *italic* is not **bold**
         let italic = Italic("italic".to_string());
         let inline_italic = Inline::Italic(italic);
         let inline_link = Inline::Anchor(anchor);
-        let text2 = Text("is not".to_string());
+        let text2 = Text("is not ".to_string());
         let inline_text2 = Inline::Text(text2);
-        let bold = Bold("italic".to_string());
+        let bold = Bold("bold".to_string());
         let inline_bold = Inline::Bold(bold);
-        let paragraph = Paragraph(vec![
+        let inlines = vec![
             inline_text,
             inline_link,
             inline_italic,
             inline_text2,
             inline_bold,
-        ]);
+        ];
+        let paragraph = Paragraph(inlines);
+        assert_eq!(res.unwrap().0, paragraph);
+    }
+
+    #[test]
+    fn it_works_inlines_without_text() {
+        let input = "[hoge](http://localhost:3000) *italic*";
+        let mut parser = parse_paragraph();
+        let res = parser.parse(input);
+        let anchor = Anchor {
+            title: "hoge".to_string(),
+            link: "http://localhost:3000".to_string(),
+        };
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inline_link = Inline::Anchor(anchor);
+        let inlines = vec![inline_link, inline_italic];
+        let paragraph = Paragraph(inlines);
         assert_eq!(res.unwrap().0, paragraph);
     }
 }

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -32,6 +32,18 @@ mod tests {
     }
 
     #[test]
+    fn it_works_simple_text() {
+        let input = "simple";
+        let mut parser = parse_paragraph();
+        let res = parser.parse(input);
+        let text = Text("simple".to_string());
+        let inline_text = Inline::Text(text);
+        let inlines = vec![inline_text];
+        let paragraph = Paragraph(inlines);
+        assert_eq!(res.unwrap().0, paragraph);
+    }
+
+    #[test]
     fn it_works_inlines() {
         let input = "aaa [hoge](http://localhost:3000) *italic* is not **bold**";
         let mut parser = parse_paragraph();

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -1,0 +1,42 @@
+use combine::{
+    parser::{
+        char::{char, space, string},
+        range::take_while1,
+    },
+    ParseError, Parser, RangeStream,
+};
+
+use crate::{ast::ast::Paragraph, Heading};
+
+pub fn parse_paragraph<'a, Input>() -> impl Parser<Input, Output = Paragraph<'a>>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    let heading_content = (
+        char('\n'),
+        take_while1(|c: char| c.is_alphabetic()),
+        char('\n'),
+    )
+        .map(|(_, content, _)| Paragraph(content));
+    heading_content
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::ast::Paragraph;
+
+    use super::parse_paragraph;
+    use combine::Parser;
+
+    #[test]
+    fn it_works(){
+        // TODO: Use indoc!
+        let input = r#"
+aaa
+"#;
+        let mut parser = parse_paragraph();
+        let res = parser.parse(input);
+        assert_eq!(res.unwrap().0, Paragraph("aaa"));
+    }
+}

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -10,6 +10,7 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let inlines = many(parse_inline());
+
     let heading_content =
         (char('\n'), inlines, char('\n')).map(|(_, content, _)| Paragraph(content));
     heading_content
@@ -29,7 +30,9 @@ mod tests {
 aaa
 "#;
         let mut parser = parse_paragraph();
+        println!("p");
         let res = parser.parse(input);
+        println!("{:?}", res);
         let text = Text("aaa".to_string());
         let inline = Inline::Text(text);
         let paragraph = Paragraph(vec![inline]);

--- a/src/ast/block/paragraph.rs
+++ b/src/ast/block/paragraph.rs
@@ -1,19 +1,23 @@
-use crate::ast::{ast::Paragraph, inline::parse_inline};
-use combine::{parser::char::char, ParseError, Parser, RangeStream};
+use crate::ast::{
+    ast::{Inline, Paragraph},
+    inline::parse_inline,
+};
+use combine::{many, parser::char::char, ParseError, Parser, RangeStream};
 
 pub fn parse_paragraph<'a, Input>() -> impl Parser<Input, Output = Paragraph>
 where
     Input: RangeStream<Token = char, Range = &'a str>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
+    let inlines = many(parse_inline());
     let heading_content =
-        (char('\n'), parse_inline(), char('\n')).map(|(_, content, _)| Paragraph(content));
+        (char('\n'), inlines, char('\n')).map(|(_, content, _)| Paragraph(content));
     heading_content
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ast::ast::{Inline, Paragraph, Text};
+    use crate::ast::ast::{Anchor, Bold, Inline, Italic, Paragraph, Text};
 
     use super::parse_paragraph;
     use combine::Parser;
@@ -28,7 +32,38 @@ aaa
         let res = parser.parse(input);
         let text = Text("aaa".to_string());
         let inline = Inline::Text(text);
-        let paragraph = Paragraph(inline);
+        let paragraph = Paragraph(vec![inline]);
+        assert_eq!(res.unwrap().0, paragraph);
+    }
+
+    #[test]
+    fn it_works_with_inlines() {
+        // TODO: Use indoc!
+        let input = r#"
+aaa [hoge](http://localhost:3000) *italic* is not **bold**
+"#;
+        let mut parser = parse_paragraph();
+        let res = parser.parse(input);
+        let text = Text("aaa".to_string());
+        let inline_text = Inline::Text(text);
+        let anchor = Anchor {
+            title: "hoge".to_string(),
+            link: "http://localhost:3000".to_string(),
+        };
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inline_link = Inline::Anchor(anchor);
+        let text2 = Text("is not".to_string());
+        let inline_text2 = Inline::Text(text2);
+        let bold = Bold("italic".to_string());
+        let inline_bold = Inline::Bold(bold);
+        let paragraph = Paragraph(vec![
+            inline_text,
+            inline_link,
+            inline_italic,
+            inline_text2,
+            inline_bold,
+        ]);
         assert_eq!(res.unwrap().0, paragraph);
     }
 }

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -26,25 +26,14 @@ where
     ))
 }
 
-pub fn parse_inlines<'a, Input>() -> impl Parser<Input, Output = Vec<Inline>>
-where
-    Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
-{
-    many(parse_inline())
-}
-
 #[cfg(test)]
 mod tests {
     use combine::Parser;
 
     use crate::ast::{
         ast::{Anchor, Bold, Inline, Italic, Text},
-        inline::{ parse_inline},
+        inline::parse_inline,
     };
-
-    use super::parse_inlines;
-
 
     #[test]
     fn it_works_bold() {
@@ -83,60 +72,5 @@ mod tests {
         let res = parser.parse(input);
         let text = Text("hello world".to_string());
         assert_eq!(res.unwrap().0, Inline::Text(text))
-    }
-
-    #[test]
-    fn it_works_inlines_with_single() {
-        let input = "*italic*";
-        let mut parser = parse_inlines();
-        let res = parser.parse(input);
-        let italic = Italic("italic".to_string());
-        let inline_italic = Inline::Italic(italic);
-        let inlines = vec![inline_italic];
-        assert_eq!(res.unwrap().0, inlines);
-    }
-
-    #[test]
-    fn it_works_inlines() {
-        let input = "aaa [hoge](http://localhost:3000) *italic* is not **bold**";
-        let mut parser = parse_inlines();
-        let res = parser.parse(input);
-        let text = Text("aaa ".to_string());
-        let inline_text = Inline::Text(text);
-        let anchor = Anchor {
-            title: "hoge".to_string(),
-            link: "http://localhost:3000".to_string(),
-        };
-        let italic = Italic("italic".to_string());
-        let inline_italic = Inline::Italic(italic);
-        let inline_link = Inline::Anchor(anchor);
-        let text2 = Text("is not ".to_string());
-        let inline_text2 = Inline::Text(text2);
-        let bold = Bold("bold".to_string());
-        let inline_bold = Inline::Bold(bold);
-        let inlines = vec![
-            inline_text,
-            inline_link,
-            inline_italic,
-            inline_text2,
-            inline_bold,
-        ];
-        assert_eq!(res.unwrap().0, inlines);
-    }
-
-    #[test]
-    fn it_works_inlines_without_text() {
-        let input = "[hoge](http://localhost:3000) *italic*";
-        let mut parser = parse_inlines();
-        let res = parser.parse(input);
-        let anchor = Anchor {
-            title: "hoge".to_string(),
-            link: "http://localhost:3000".to_string(),
-        };
-        let italic = Italic("italic".to_string());
-        let inline_italic = Inline::Italic(italic);
-        let inline_link = Inline::Anchor(anchor);
-        let inlines = vec![inline_link, inline_italic];
-        assert_eq!(res.unwrap().0, inlines);
     }
 }

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -1,4 +1,5 @@
-use combine::{attempt, choice, ParseError, Parser, Stream};
+use combine::parser::char::{char, spaces};
+use combine::{attempt, choice, many, opaque, ParseError, Parser, Stream, parser::char::space};
 
 use self::bold::parse_bold;
 use self::italic::parse_italic;
@@ -18,11 +19,29 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     choice((
-        attempt(parse_bold()),
-        attempt(parse_italic()),
-        attempt(parse_anchor()),
-        attempt(parse_text()),
+        attempt(parse_bold().skip(spaces())),
+        attempt(parse_italic().skip(spaces())),
+        attempt(parse_anchor().skip(spaces())),
+        attempt(parse_text().skip(spaces())),
     ))
+}
+
+pub fn parse_inlines<'a, Input>() -> impl Parser<Input, Output = Vec<Inline>>
+where
+    Input: Stream<Token = char>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    many(parse_inline())
+}
+
+fn experiment<'a, Input>() -> impl Parser<Input, Output = Vec<char>>
+where
+    Input: Stream<Token = char>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+        many(choice(
+            (attempt(char('b')), attempt(char('c')))
+        ))
 }
 
 #[cfg(test)]
@@ -31,8 +50,18 @@ mod tests {
 
     use crate::ast::{
         ast::{Anchor, Bold, Inline, Italic, Text},
-        inline::parse_inline,
+        inline::{parse_inline, experiment},
     };
+
+    use super::parse_inlines;
+
+    #[test]
+    fn it_works_ex() {
+        let input = "bcc";
+        let mut parser = experiment();
+        let res = parser.parse(input);
+        assert_eq!(res.unwrap().0, vec!['b', 'c', 'c'])
+    }
 
     #[test]
     fn it_works_bold() {
@@ -66,10 +95,70 @@ mod tests {
 
     #[test]
     fn it_works_text() {
-        let input = "hello";
+        let input = "hello world";
         let mut parser = parse_inline();
         let res = parser.parse(input);
-        let text = Text("hello".to_string());
+        let text = Text("hello world".to_string());
         assert_eq!(res.unwrap().0, Inline::Text(text))
+    }
+
+    #[test]
+    fn it_works_inlines_with_single() {
+        let input = "*italic*";
+        let mut parser = parse_inlines();
+        let res = parser.parse(input);
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inlines = vec![
+            inline_italic,
+        ];
+        assert_eq!(res.unwrap().0, inlines);
+    }
+
+    #[test]
+    fn it_works_inlines() {
+        let input = "aaa [hoge](http://localhost:3000) *italic* is not **bold**";
+        let mut parser = parse_inlines();
+        let res = parser.parse(input);
+        let text = Text("aaa".to_string());
+        let inline_text = Inline::Text(text);
+        let anchor = Anchor {
+            title: "hoge".to_string(),
+            link: "http://localhost:3000".to_string(),
+        };
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inline_link = Inline::Anchor(anchor);
+        let text2 = Text("is not".to_string());
+        let inline_text2 = Inline::Text(text2);
+        let bold = Bold("italic".to_string());
+        let inline_bold = Inline::Bold(bold);
+        let inlines = vec![
+            inline_text,
+            inline_link,
+            inline_italic,
+            inline_text2,
+            inline_bold,
+        ];
+        assert_eq!(res.unwrap().0, inlines);
+    }
+
+    #[test]
+    fn it_works_inlines_without_text() {
+        let input = "[hoge](http://localhost:3000) *italic*";
+        let mut parser = parse_inlines();
+        let res = parser.parse(input);
+        let anchor = Anchor {
+            title: "hoge".to_string(),
+            link: "http://localhost:3000".to_string(),
+        };
+        let italic = Italic("italic".to_string());
+        let inline_italic = Inline::Italic(italic);
+        let inline_link = Inline::Anchor(anchor);
+        let inlines = vec![
+            inline_link,
+            inline_italic,
+        ];
+        assert_eq!(res.unwrap().0, inlines);
     }
 }

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -12,7 +12,7 @@ pub mod italic;
 pub mod link;
 pub mod text;
 
-fn parse_inline<'a, Input>() -> impl Parser<Input, Output = Inline>
+pub fn parse_inline<'a, Input>() -> impl Parser<Input, Output = Inline>
 where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
@@ -21,7 +21,7 @@ where
         attempt(parse_bold()),
         attempt(parse_italic()),
         attempt(parse_anchor()),
-        attempt(parse_text())
+        attempt(parse_text()),
     ))
 }
 
@@ -54,16 +54,7 @@ mod tests {
 
     #[test]
     fn it_works_link() {
-        let input = "hello";
-        let mut parser = parse_inline();
-        let res = parser.parse(input);
-        let text = Text("hello".to_string());
-        assert_eq!(res.unwrap().0, Inline::Text(text))
-    }
-
-    #[test]
-    fn it_works_text() {
-        let input = "aaa";
+        let input = "[test](http://localhost:3000)";
         let mut parser = parse_inline();
         let res = parser.parse(input);
         let anchor = Anchor {
@@ -71,5 +62,14 @@ mod tests {
             link: "http://localhost:3000".to_string(),
         };
         assert_eq!(res.unwrap().0, Inline::Anchor(anchor))
+    }
+
+    #[test]
+    fn it_works_text() {
+        let input = "hello";
+        let mut parser = parse_inline();
+        let res = parser.parse(input);
+        let text = Text("hello".to_string());
+        assert_eq!(res.unwrap().0, Inline::Text(text))
     }
 }

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -9,6 +9,7 @@ use super::ast::Inline;
 pub mod bold;
 pub mod italic;
 pub mod link;
+pub mod text;
 
 fn parse_inline<'a, Input>() -> impl Parser<Input, Output = Inline>
 where

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -15,7 +15,11 @@ where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    choice((attempt(parse_bold()), attempt(parse_italic()), attempt(parse_anchor())))
+    choice((
+        attempt(parse_bold()),
+        attempt(parse_italic()),
+        attempt(parse_anchor()),
+    ))
 }
 
 #[cfg(test)]
@@ -23,7 +27,7 @@ mod tests {
     use combine::Parser;
 
     use crate::ast::{
-        ast::{Bold, Inline, Italic, Anchor},
+        ast::{Anchor, Bold, Inline, Italic},
         inline::parse_inline,
     };
 

--- a/src/ast/inline.rs
+++ b/src/ast/inline.rs
@@ -3,6 +3,7 @@ use combine::{attempt, choice, ParseError, Parser, Stream};
 use self::bold::parse_bold;
 use self::italic::parse_italic;
 use self::link::parse_anchor;
+use self::text::parse_text;
 
 use super::ast::Inline;
 
@@ -20,6 +21,7 @@ where
         attempt(parse_bold()),
         attempt(parse_italic()),
         attempt(parse_anchor()),
+        attempt(parse_text())
     ))
 }
 
@@ -28,7 +30,7 @@ mod tests {
     use combine::Parser;
 
     use crate::ast::{
-        ast::{Anchor, Bold, Inline, Italic},
+        ast::{Anchor, Bold, Inline, Italic, Text},
         inline::parse_inline,
     };
 
@@ -51,8 +53,17 @@ mod tests {
     }
 
     #[test]
-    fn it_works() {
-        let input = "[test](http://localhost:3000)";
+    fn it_works_link() {
+        let input = "hello";
+        let mut parser = parse_inline();
+        let res = parser.parse(input);
+        let text = Text("hello".to_string());
+        assert_eq!(res.unwrap().0, Inline::Text(text))
+    }
+
+    #[test]
+    fn it_works_text() {
+        let input = "aaa";
         let mut parser = parse_inline();
         let res = parser.parse(input);
         let anchor = Anchor {

--- a/src/ast/inline/text.rs
+++ b/src/ast/inline/text.rs
@@ -1,4 +1,4 @@
-use combine::{between, many, parser::char::string, satisfy, ParseError, Parser, Stream, many1};
+use combine::{between, many, many1, parser::char::string, satisfy, ParseError, Parser, Stream};
 
 use crate::ast::ast::{Bold, Inline, Text};
 

--- a/src/ast/inline/text.rs
+++ b/src/ast/inline/text.rs
@@ -1,0 +1,32 @@
+use combine::{between, many, parser::char::string, satisfy, ParseError, Parser, Stream};
+
+use crate::ast::ast::{Bold, Inline, Text};
+
+pub fn parse_text<'a, Input>() -> impl Parser<Input, Output = Inline>
+where
+    Input: Stream<Token = char>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    many(satisfy(|_| true)).map(|name: String| {
+        let text = Text(name);
+        Inline::Text(text)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use combine::Parser;
+
+    use crate::ast::{
+        ast::{ Inline, Text}, inline::text::parse_text,
+    };
+
+    #[test]
+    fn it_works() {
+        let input = "hello";
+        let mut parser = parse_text();
+        let res = parser.parse(input);
+        let text = Text("hello".to_string());
+        assert_eq!(res.unwrap().0, Inline::Text(text))
+    }
+}

--- a/src/ast/inline/text.rs
+++ b/src/ast/inline/text.rs
@@ -1,4 +1,4 @@
-use combine::{between, many, many1, parser::char::string, satisfy, ParseError, Parser, Stream};
+use combine::{between, many1, parser::char::string, satisfy, ParseError, Parser, Stream};
 
 use crate::ast::ast::{Bold, Inline, Text};
 
@@ -8,7 +8,8 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let f = |c| {
-        let bool = c != '\n' && c != '[' && c != ']' && c != '(' && c != ')' && c != '*';
+        let bool =
+            c != '\n' && c != '[' && c != ']' && c != '(' && c != ')' && c != '*' && c != '#';
         bool
     };
     // HACK: 特別な意味を持つ文字を消費しないようにする(本当にこれしか方法ない？)

--- a/src/ast/inline/text.rs
+++ b/src/ast/inline/text.rs
@@ -7,7 +7,8 @@ where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    many(satisfy(|_| true)).map(|name: String| {
+    // HACK: 特別な意味を持つ文字を消費しないようにする(本当にこれしか方法ない？)
+    many(satisfy(|c| c != '\n' && c != '[' && c != '*')).map(|name: String| {
         let text = Text(name);
         Inline::Text(text)
     })
@@ -18,7 +19,8 @@ mod tests {
     use combine::Parser;
 
     use crate::ast::{
-        ast::{ Inline, Text}, inline::text::parse_text,
+        ast::{Inline, Text},
+        inline::text::parse_text,
     };
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn main() {
 
 ## h2
 
+## h3
 "#);
     println!("{:?}", parsed);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,35 +5,9 @@ use combine::{choice, error::ParseError, parser::char::char, Parser, Stream};
 mod ast;
 use crate::ast::ast::{Ast, Heading};
 
-fn parse_md<'a, Input>() -> impl Parser<Input, Output = Ast<'a>>
-where
-    Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
-{
-    let parsed = choice((parse_block(), parse_inline()));
-    parsed
-}
 
-fn parse_inline<'a, Input>() -> impl Parser<Input, Output = Ast<'a>>
-where
-    Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
-{
-    let tok = char('*').map(|_| Ast::Inline);
-    tok
-}
-
-fn parse_block<'a, Input>() -> impl Parser<Input, Output = Ast<'a>>
-where
-    Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
-{
-    let tok = char('*').map(|_| Ast::Inline);
-    tok
-}
 
 fn main() {
-    let res = parse_md().parse("3*(1+2)");
-    println!("{:?}", res)
+    println!("aaa")
     // Ok((Prod(Scalar(3.0), Sum(Scalar(1.0), Scalar(2.0))), ""))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,41 @@
 extern crate combine;
 
-use combine::{choice, error::ParseError, parser::char::char, Parser, Stream};
+use ast::ast::LeafBlock;
+use ast::{ast::Document, block::parse_block};
+use combine::{attempt, many1};
+use combine::{choice, error::ParseError, parser::char::char, Parser, RangeStream, Stream};
 
 mod ast;
-use crate::ast::ast::{Ast, Heading};
+use crate::ast::ast::Heading;
+use crate::ast::inline::parse_inline;
 
+fn parse_blocks<'a, Input>() -> impl Parser<Input, Output = Vec<LeafBlock>>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    let block = (parse_block(), char('\n')).map(|(x, _)| x);
+    many1(block)
+}
 
+fn parse_doc<'a, Input>() -> impl Parser<Input, Output = Document>
+where
+    Input: RangeStream<Token = char, Range = &'a str>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
+{
+    choice((
+        attempt(parse_blocks()).map(|x| Document::LeafBlocks(x)),
+        attempt(parse_inline()).map(|x| Document::Inline(x)),
+    ))
+}
 
 fn main() {
-    println!("aaa")
-    // Ok((Prod(Scalar(3.0), Sum(Scalar(1.0), Scalar(2.0))), ""))
+    let parsed = parse_doc().parse(r#"# h1
+
+## h2
+
+aaa
+
+"#);
+    println!("{:?}", parsed);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,6 @@ fn main() {
 
 ## h2
 
-aaa
-
 "#);
     println!("{:?}", parsed);
 }


### PR DESCRIPTION
```rust
fn main() {
    let parsed = parse_doc().parse(r#"# h1

## h2

aaaa
"#);
    println!("{:?}", parsed);
}
```

が parse できない。

```rust
fn main() {
    let parsed = parse_doc().parse(r#"# h1

## h2

### h3
"#);
    println!("{:?}", parsed);
}
```

は parse できる。